### PR TITLE
Updated sources to 0.15, align recipe with upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.11.1" %}
-{% set sha256 = "25f040b04ae0c8473fe57af009c7c83bd9122a88b8ef5b19dd4805812fe03d24" %}
+{% set version = "0.15.0" %}
+{% set sha256 = "e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9" %}
 
 package:
   name: scikit-build
@@ -10,21 +10,17 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  noarch: python
 
 requirements:
-  build:
-    - cmake
-    - ninja
-    - pip
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
     - packaging
     - pip
     - python
     - setuptools
+    - setuptools_scm
     - wheel
   run:
     - cmake
@@ -41,19 +37,17 @@ test:
   source_files:
     - tests/*
   requires:
-    - {{ compiler('c') }}  # [unix]
-    - {{ compiler('cxx') }}  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - make  # [unix]
     - mock
     - path.py
+    - pip
     - pytest
     - pytest-mock
     - pytest-cov
-    - pytest-runner
     - six
     - git
-    - cmake
-    - ninja
     - cython
     - requests
 


### PR DESCRIPTION
This Pr updates sources to 0.15.0 and makes changes to the recipe to align it with version used by conda-forge.