### PR TITLE
scikit-build 0.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - python
     - cmake
     - distro
-    - make
+    - make  # [not win]
     - packaging
     - setuptools >=42.0.0
     - wheel >=0.32.0
@@ -46,7 +46,7 @@ test:
     - cmake
     - cython
     - git
-    - make
+    - make  # not win[]
     - mock
     - ninja
     - path.py >=11.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,11 @@ build:
 requirements:
   host:
     - python
+    - cython >=0.25.1
     - packaging
+    - path.py >=11.5.0
     - pip
+    - python-build >=0.7
     - setuptools >=42
     - setuptools_scm
     - toml
@@ -38,12 +41,12 @@ test:
   source_files:
     - tests/*
   requires:
-    - {{ compiler('c') }}  # [unix]
-    - {{ compiler('cxx') }}  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
     - cython
     - git
-    - make  # [unix]
+    - make
     - mock
     - ninja
     - path.py >=11.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ about:
     fundamentally just glue between the setuptools Python module and CMake.
 
   doc_url: https://scikit-build.readthedocs.org
-  dev_url: https ://github.com/scikit-build/scikit-build
+  dev_url: https://github.com/scikit-build/scikit-build
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - cmake
     - cython
     - git
-    - make  # not win[]
+    - make  # [not win]
     - mock
     - ninja
     - path.py >=11.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,36 @@
-{% set version = "0.11.1" %}
-{% set sha256 = "25f040b04ae0c8473fe57af009c7c83bd9122a88b8ef5b19dd4805812fe03d24" %}
+{% set name = "scikit-build" %}
+{% set version = "0.15.0" %}
+{% set sha256 = "e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9" %}
 
 package:
-  name: scikit-build
+  name:  {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/scikit-build/scikit-build/archive/{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/scikit-build/scikit-build-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
-  build:
-    - cmake
-    - ninja
-    - pip
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
+    - python
     - packaging
     - pip
-    - python
-    - setuptools
+    - setuptools >=42
+    - setuptools_scm
+    - toml
     - wheel
   run:
+    - python
     - cmake
     - distro
+    - make
     - packaging
-    - python
-    - ninja
-    - setuptools
-    - wheel
+    - setuptools >=42.0.0
+    - wheel >=0.32.0
 
 test:
   imports:
@@ -43,28 +40,37 @@ test:
   requires:
     - {{ compiler('c') }}  # [unix]
     - {{ compiler('cxx') }}  # [unix]
+    - cmake
+    - cython
+    - git
     - make  # [unix]
     - mock
-    - path.py
-    - pytest
-    - pytest-mock
-    - pytest-cov
-    - pytest-runner
-    - six
-    - git
-    - cmake
     - ninja
-    - cython
+    - path.py >=11.5.0
+    - pip
+    - pytest >=4.5.0
+    - pytest-cov >=2.7.1
+    - pytest-mock >=1.10.4
+    - pytest-runner >=5.1
     - requests
+    - six >=1.10.0
 
 about:
-  home: http://github.com/scikit-build/scikit-build
+  home: https://github.com/scikit-build/scikit-build
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  license_url: https://github.com/scikit-build/scikit-build/blob/master/LICENSE
   summary: Improved build system generator for CPython C extensions.
-  doc_url: http://scikit-build.readthedocs.org
-  dev_url: http://github.com/scikit-build/scikit-build
+  description: |
+    scikit-build is an improved build system generator for CPython
+    C/C++/Fortran/Cython extensions. It provides better support for additional
+    compilers, build systems, cross compilation, and locating dependencies and
+    their associated build requirements. The scikit-build package is
+    fundamentally just glue between the setuptools Python module and CMake.
+
+  doc_url: https://scikit-build.readthedocs.org
+  dev_url: https ://github.com/scikit-build/scikit-build
 
 extra:
   recipe-maintainers:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -8,4 +8,4 @@ popd
 
 %PYTHON% -m pip check
 
-py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_install_dir_keyword and not test_generator_selection and not pep518 and not test_configure_with_cmake_args" -v
+py.test -k "not (test_fortran_compiler or test_issue352_isolated_environment_support or test_cmake_install_dir_keyword or test_generator_selection or pep518 or test_configure_with_cmake_args or test_make_with_install_target)" -v

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -6,4 +6,6 @@ call rmpath C:\\ProgramData\\Chocolatey\\bin
 call rmpath C:\\Strawberry\\c\\bin
 popd
 
-py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_install_dir_keyword and not test_generator_selection" -v
+%PYTHON% -m pip check
+
+py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_install_dir_keyword and not test_generator_selection and not pep518 and not test_configure_with_cmake_args" -v

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,3 +1,3 @@
 $PYTHON -m pip check
 
-py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_args_keyword_osx_default and not pep518 and not test_configure_with_cmake_args" -v
+py.test -k "not (test_fortran_compiler or test_issue352_isolated_environment_support or test_cmake_install_dir_keyword or test_generator_selection or pep518 or test_configure_with_cmake_args)" -v

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,3 +1,3 @@
 $PYTHON -m pip check
 
-py.test -k "not (test_fortran_compiler or test_issue352_isolated_environment_support or test_cmake_install_dir_keyword or test_generator_selection or pep518 or test_configure_with_cmake_args)" -v
+py.test -k "not (test_fortran_compiler or test_issue352_isolated_environment_support or test_cmake_install_dir_keyword or test_generator_selection or pep518 or test_configure_with_cmake_args or test_cmake_args_keyword_osx_default)" -v

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,1 +1,3 @@
-py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_args_keyword_osx_default" -v
+$PYTHON -m pip check
+
+py.test -k "not test_fortran_compiler and not test_issue352_isolated_environment_support and not test_cmake_args_keyword_osx_default and not pep518 and not test_configure_with_cmake_args" -v


### PR DESCRIPTION
Changelog: https://github.com/scikit-build/scikit-build/blob/0.15.0/CHANGES.rst
License: https://github.com/scikit-build/scikit-build/blob/master/LICENSE
Requirements:
- https://github.com/scikit-build/scikit-build/blob/0.15.0/pyproject.toml
- https://github.com/scikit-build/scikit-build/blob/0.15.0/requirements-dev.txt
- https://github.com/scikit-build/scikit-build/blob/0.15.0/requirements.txt
- https://github.com/scikit-build/scikit-build/blob/0.15.0/setup.py
- https://scikit-build.readthedocs.io/en/latest/installation.html#dependencies

Actions:
1. Add more `jinja2` templates
2. Update `source/url` because the `pypi` url is required only
3. Remove the `requirements/build` section. It seems that it's not needed for building a package
4. Update `host` dependencies: 
- add `cython`, `path.py`, `python-build` because they are mentioned as the build time dependencies https://scikit-build.readthedocs.io/en/latest/installation.html#python-packages but `conda-forge` does not use them. 
- add `setuptools_scm` and `toml`.
6. Update `run` dependencies & pinnings: 
- `make` is available only on `unix`.
- add pinnings for `setuptools` and `wheel`, see https://scikit-build.readthedocs.io/en/latest/installation.html#python-packages
7. Reorder `test/requires` and add pinnings
8. Add a `description`
9. Add `license_url`
10. Fix home, doc, dev urls with HTTPS
11. Skip tests `pep518` and `test_configure_with_cmake_args`