### PR TITLE
scikit-build 0.15.0: Rebuild for py312 on win64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:


### PR DESCRIPTION
Missing artifacts for py312 on win64, see https://github.com/AnacondaRecipes/rapidfuzz-feedstock/pull/6#issuecomment-2188170413. We can ignore other failing platforms